### PR TITLE
Refactor: Simplify analyzer output

### DIFF
--- a/biaslens/analyzer.py
+++ b/biaslens/analyzer.py
@@ -95,28 +95,31 @@ class BiasLensAnalyzer:
             )
 
             # Performance metrics
-            processing_time = round(time.time() - start_time, 3)
+            # processing_time = round(time.time() - start_time, 3) # No longer returning full dict
 
+            # Construct the specific dictionary as per requirements
             return {
-                'status': 'success',
-                'overall_assessment': overall_assessment,
-                'trust_score': trust_result,
-                'analysis': {
-                    'sentiment': sentiment_result,
-                    'emotion': emotion_result,
-                    'bias': bias_result,
-                    'patterns': pattern_result
-                },
-                'metadata': {
-                    'processing_time_seconds': processing_time,
-                    'text_length': len(text),
-                    'initialized_components': list(self._initialized_components),
-                    'analysis_timestamp': time.time()
-                }
+                'trust_score': trust_result.get('score'),
+                'indicator': trust_result.get('indicator'),
+                'explanation': trust_result.get('explanation'),
+                'tip': trust_result.get('tip')
             }
 
         except Exception as e:
-            return self._get_error_analysis_result(str(e), time.time() - start_time)
+            # If an error occurs, we should still try to return a dictionary
+            # that hints at the expected structure, or a more specific error.
+            # For now, let's re-raise or return a simplified error structure.
+            # This part might need further refinement based on error handling strategy for the new return type.
+            # However, the original _get_error_analysis_result returns a dict with 'status', 'error', 'overall_assessment', 'metadata'
+            # which is not compatible with the new required return type.
+            # For the scope of this task, focusing on the successful case.
+            # A simple error indication:
+            return {
+                'trust_score': None,
+                'indicator': 'Error',
+                'explanation': [f"An error occurred: {str(e)}"],
+                'tip': 'Analysis failed'
+            }
 
     def quick_analyze(self, text: str) -> Dict:
         """
@@ -143,22 +146,19 @@ class BiasLensAnalyzer:
             )
 
             return {
-                'status': 'success',
-                'mode': 'quick_analysis',
-                'trust_score': basic_trust_score,
-                'sentiment': sentiment_result,
-                'patterns': {
-                    'nigerian_patterns': nigerian_patterns,
-                    'fake_news_risk': fake_details if fake_detected else None
-                },
-                'metadata': {
-                    'processing_time_seconds': round(time.time() - start_time, 3),
-                    'text_length': len(text)
-                }
+                'score': basic_trust_score.get('score'),
+                'indicator': basic_trust_score.get('indicator'),
+                'explanation': basic_trust_score.get('explanation'),
+                'tip': "For a more comprehensive analysis, use the full analyze function."
             }
 
         except Exception as e:
-            return self._get_error_analysis_result(str(e), time.time() - start_time)
+            return {
+                'score': None,
+                'indicator': 'Error',
+                'explanation': [f"An error occurred during quick analysis: {str(e)}"],
+                'tip': "For a more comprehensive analysis, use the full analyze function."
+            }
 
     def analyze_headline_content_mismatch(self, headline: str, content: str) -> Dict:
         """

--- a/test.py
+++ b/test.py
@@ -1,3 +1,32 @@
 from biaslens.analyzer import quick_analyze, analyze
 
-result = quick_analyze("BREAKING: THE WORLD ENDS IN TWO WEEKS")
+# Test for quick_analyze
+print("Testing quick_analyze...")
+quick_result = quick_analyze("BREAKING: THE WORLD ENDS IN TWO WEEKS")
+print(f"quick_analyze output: {quick_result}")
+
+assert 'score' in quick_result, "quick_analyze output missing 'score'"
+assert 'indicator' in quick_result, "quick_analyze output missing 'indicator'"
+assert 'explanation' in quick_result, "quick_analyze output missing 'explanation'"
+assert isinstance(quick_result['explanation'], list), "quick_analyze 'explanation' should be a list"
+assert 'tip' in quick_result, "quick_analyze output missing 'tip'"
+assert quick_result['tip'] == "For a more comprehensive analysis, use the full analyze function.", "Incorrect tip in quick_analyze"
+
+print("quick_analyze tests passed!")
+print("-" * 20)
+
+# Test for analyze
+print("Testing analyze...")
+analyze_result = analyze("The government announced new policies today regarding renewable energy. Some say this is a great step, while others are concerned about the economic impact.")
+print(f"analyze output: {analyze_result}")
+
+assert 'trust_score' in analyze_result, "analyze output missing 'trust_score'"
+assert 'indicator' in analyze_result, "analyze output missing 'indicator'"
+assert 'explanation' in analyze_result, "analyze output missing 'explanation'"
+assert isinstance(analyze_result['explanation'], list), "analyze 'explanation' should be a list"
+assert 'tip' in analyze_result, "analyze output missing 'tip'"
+
+print("analyze tests passed!")
+print("-" * 20)
+
+print("All tests in test.py passed!")


### PR DESCRIPTION
I modified the `analyze` and `quick_analyze` functions in `biaslens/analyzer.py` to return only the most relevant information to you.

- The `analyze` function now returns a dictionary with 'trust_score', 'indicator', 'explanation', and 'tip'.
- The `quick_analyze` function now returns a dictionary with 'score', 'indicator', 'explanation', and a default 'tip'.
- I updated `test.py` to reflect these changes and added a test case for the `analyze` function.

This change addresses your request to reduce the amount of information in the output and focus on key bias and misinformation detection metrics.