### PR TITLE
feat: Make detected bias type more explicit in analyzer output

### DIFF
--- a/biaslens/analyzer.py
+++ b/biaslens/analyzer.py
@@ -131,11 +131,22 @@ class BiasLensAnalyzer:
 
             overall_processing_time = round(time.time() - overall_start_time, 4)
 
+            primary_bias_type_value = None # Default
+            if bias_result.get('flag'):
+                bias_type_info = bias_result.get('type_analysis', {})
+                detected_type = bias_type_info.get('type')
+                if detected_type and detected_type not in ['neutral', 'no bias', 'analysis_error']:
+                    primary_bias_type_value = detected_type
+                elif detected_type in ['neutral', 'no bias']:
+                    primary_bias_type_value = "neutral"
+                # if 'analysis_error' or None, it remains None or its previous default
+
             final_result = {
                 'trust_score': trust_result.get('score'),
                 'indicator': trust_result.get('indicator'),
                 'explanation': trust_result.get('explanation'),
                 'tip': trust_result.get('tip'),
+                'primary_bias_type': primary_bias_type_value, # New key
                 'metadata': {
                     'component_processing_times': component_processing_times,
                     'overall_processing_time_seconds': overall_processing_time,

--- a/biaslens/trust.py
+++ b/biaslens/trust.py
@@ -87,6 +87,16 @@ class TrustScoreCalculator:
                     score -= 20
                     explanation.append("Potential bias detected in language patterns.")
                     risk_factors.append("moderate_bias")
+
+                # Add specific bias type to explanation
+                bias_type_info = bias_data.get('type_analysis', {})
+                detected_bias_type = bias_type_info.get('type')
+
+                if detected_bias_type and detected_bias_type not in ['neutral', 'no bias', 'analysis_error', None]:
+                    explanation.append(f"Dominant bias type identified: {detected_bias_type.replace('_', ' ').title()}.")
+                elif detected_bias_type == 'neutral' or detected_bias_type == 'no bias':
+                    explanation.append("Bias type analysis indicates neutrality.")
+                # If 'analysis_error' or None, no specific type explanation is added for type
         else:
             # Fallback to legacy scoring
             if bias_score >= 0.8:

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -74,7 +74,8 @@ class TestBiasLensAnalyzer(unittest.TestCase):
         # Configure mocks to return basic valid structures
         mock_analyze_sentiment_safe.return_value = {'label': 'neutral', 'confidence': 0.9, 'all_scores': {}, 'bias_indicator': False}
         mock_analyze_emotion_safe.return_value = {'label': 'neutral', 'confidence': 0.8, 'manipulation_risk': 'minimal', 'is_emotionally_charged': False}
-        mock_analyze_bias_safe.return_value = {'flag': False, 'label': 'Likely Neutral', 'type_analysis': {'type': 'neutral', 'confidence': 90}}
+        # For a general valid text, assume no bias flag, leading to primary_bias_type being None
+        mock_analyze_bias_safe.return_value = {'flag': False, 'label': 'Likely Neutral', 'type_analysis': {'type': 'neutral', 'confidence': 90.0}}
         mock_analyze_patterns_safe.return_value = {'nigerian_patterns': {}, 'fake_news': {'detected': False}, 'viral_manipulation': {}}
         # Mock the trust score calculation to return a predictable structure
         mock_calculate_trust_score_safe.return_value = {
@@ -96,12 +97,63 @@ class TestBiasLensAnalyzer(unittest.TestCase):
         self.assertIn('explanation', analysis)
         self.assertIsInstance(analysis['explanation'], list)
         self.assertIn('tip', analysis)
+        self.assertIn('primary_bias_type', analysis) # Check for the new key
+        self.assertIsNone(analysis['primary_bias_type']) # Expect None when bias_result['flag'] is False
         self.assertIn('metadata', analysis)
         self.assertIn('component_processing_times', analysis['metadata'])
         self.assertIn('overall_processing_time_seconds', analysis['metadata'])
         self.assertIn('text_length', analysis['metadata'])
         self.assertIn('initialized_components', analysis['metadata'])
         self.assertIn('analysis_timestamp', analysis['metadata'])
+
+    @patch('biaslens.analyzer.BiasLensAnalyzer._analyze_sentiment_safe')
+    @patch('biaslens.analyzer.BiasLensAnalyzer._analyze_emotion_safe')
+    @patch('biaslens.analyzer.BiasLensAnalyzer._analyze_bias_safe')
+    @patch('biaslens.analyzer.BiasLensAnalyzer._analyze_patterns_safe')
+    @patch('biaslens.analyzer.BiasLensAnalyzer._calculate_trust_score_safe')
+    @patch('biaslens.analyzer.BiasLensAnalyzer._generate_overall_assessment')
+    def test_analyze_specific_bias_type_detected(self,
+                                                 mock_generate_overall_assessment,
+                                                 mock_calculate_trust_score_safe,
+                                                 mock_analyze_patterns_safe,
+                                                 mock_analyze_bias_safe,
+                                                 mock_analyze_emotion_safe,
+                                                 mock_analyze_sentiment_safe):
+        """Test analyze output when a specific bias type is detected and explained."""
+        # Configure mocks
+        mock_analyze_sentiment_safe.return_value = {'label': 'neutral', 'confidence': 0.9, 'all_scores': {}, 'bias_indicator': False}
+        mock_analyze_emotion_safe.return_value = {'label': 'neutral', 'confidence': 0.8, 'manipulation_risk': 'minimal', 'is_emotionally_charged': False}
+
+        # Mock bias detection to indicate a specific bias
+        mock_bias_type = "political_bias" # Use underscore version as it comes from model/classification
+        mock_analyze_bias_safe.return_value = {
+            'flag': True,
+            'label': 'Potentially Biased - High Confidence',
+            'type_analysis': {'type': mock_bias_type, 'confidence': 95.0, 'all_predictions': []}
+        }
+
+        mock_analyze_patterns_safe.return_value = {'nigerian_patterns': {}, 'fake_news': {'detected': False}, 'viral_manipulation': {}}
+
+        # Mock trust score to include the specific bias explanation from TrustScoreCalculator
+        # This part assumes TrustScoreCalculator correctly formats the bias type in its explanation
+        expected_explanation_fragment = f"Dominant bias type identified: {mock_bias_type.replace('_', ' ').title()}."
+        mock_calculate_trust_score_safe.return_value = {
+            'score': 40,
+            'indicator': '🟡 Caution',
+            'explanation': ['High confidence bias detected in language patterns.', expected_explanation_fragment],
+            'tip': 'Verify this content.',
+            'trust_level': 'high_caution', 'risk_factors': ['high_bias'], 'summary': 'Concerning.', 'pattern_analysis': {}
+        }
+        mock_generate_overall_assessment.return_value = {}
+
+        analysis = analyze("This text has clear political bias.")
+
+        self.assertIsNotNone(analysis)
+        self.assertEqual(analysis.get('primary_bias_type'), mock_bias_type)
+        # The explanation in the final result comes from trust_result.get('explanation')
+        # So we check if the mock_calculate_trust_score_safe's explanation is passed through.
+        self.assertIn(expected_explanation_fragment, analysis.get('explanation', []))
+        self.assertIn('High confidence bias detected in language patterns.', analysis.get('explanation', []))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit enhances the output of the `analyze` function to provide you with clearer and more direct information about the type of bias detected.

Key changes:

- **`biaslens/analyzer.py`**:
    - The main dictionary returned by `BiasLensAnalyzer.analyze` now includes a `primary_bias_type` key. This key holds the string of the classified bias type (e.g., "political bias") if specific bias is detected, or "neutral"/`None` otherwise.

- **`biaslens/trust.py`**:
    - The `TrustScoreCalculator.calculate` method has been updated. When a specific type of bias is flagged by `bias_data`, the `explanation` list returned by the calculator now includes a more direct statement, such as "Dominant bias type identified: Political Bias."

- **`tests/test_analyzer.py`**:
    - Unit tests have been updated to reflect these changes.
    - The `test_analyze_valid_text_structure` test now asserts the presence and expected value of `primary_bias_type` in a no-bias scenario.
    - A new test, `test_analyze_specific_bias_type_detected`, has been added to specifically verify that when a bias type is mocked as detected, both the `primary_bias_type` field and the `explanation` list correctly reflect this.

These changes allow you to more easily identify the specific nature of bias found in the analyzed text directly from the primary output fields.