### PR TITLE
feat: Wire up Quick Analysis button to quick_analyze backend function

### DIFF
--- a/biaslens/analyzer.py
+++ b/biaslens/analyzer.py
@@ -571,3 +571,28 @@ def quick_analyze(text: str) -> Dict:
     """
     # Uses the global analyzer instance
     return _global_analyzer.quick_analyze(text)
+
+
+if __name__ == "__main__":
+    import sys
+    import json
+
+    if len(sys.argv) != 3:
+        print("Usage: python analyzer.py <analyze|quick_analyze> <text_to_analyze>", file=sys.stderr)
+        sys.exit(1)
+
+    function_to_call = sys.argv[1]
+    text_input = sys.argv[2]
+
+    result = None
+    if function_to_call == "analyze":
+        # The existing global 'analyze' function can take more arguments,
+        # but for CLI, we'll use defaults for include_patterns, headline, etc.
+        result = analyze(text_input)
+    elif function_to_call == "quick_analyze":
+        result = quick_analyze(text_input)
+    else:
+        print(f"Unknown function: {function_to_call}. Choose 'analyze' or 'quick_analyze'.", file=sys.stderr)
+        sys.exit(1)
+
+    print(json.dumps(result))

--- a/frontend/app/analyze/page.tsx
+++ b/frontend/app/analyze/page.tsx
@@ -85,6 +85,70 @@ export default function AnalyzePage() {
     }
   }
 
+  // Add this new handler function within AnalyzePage component
+  const handleQuickAnalyze = async () => {
+    if (!text.trim()) {
+      toast({
+        title: "Error",
+        description: "Please enter some text to analyze",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setAnalyzing(true);
+    setResult(null); // Clear previous results
+
+    try {
+      const response = await fetch("/api/quick_analyze", { // Changed endpoint
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          text: text.trim(),
+          userId: user?.id, // userId might not be used by quick_analyze endpoint but sent for consistency
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.error || "Quick analysis failed");
+      }
+
+      const quickResult = await response.json();
+
+      // Map quickResult to the existing AnalysisResult structure
+      // Some fields will be missing or adapted
+      const mappedResult: Partial<AnalysisResult> = {
+        // id and createdAt would typically come if it were saved and returned by DB
+        trustScore: quickResult.score,
+        sentiment: quickResult.indicator, // Or map more appropriately if needed
+        biasType: "N/A for Quick Analysis", // Placeholder
+        emotionalLanguage: [], // Placeholder
+        misinformationFlag: false, // Placeholder, unless quick_analyze provides this
+        explanation: Array.isArray(quickResult.explanation) ? quickResult.explanation.join("\\n") : quickResult.explanation,
+        summary: quickResult.tip, // Using 'tip' as a summary
+      };
+
+      setResult(mappedResult as AnalysisResult); // Cast, acknowledging missing fields
+
+      toast({
+        title: "Quick Analysis Complete",
+        description: "Your text has been quickly analyzed!",
+      });
+    } catch (error) {
+      toast({
+        title: "Error",
+        description: error instanceof Error ? error.message : "Failed to perform quick analysis. Please try again.",
+        variant: "destructive",
+      });
+      setResult(null); // Clear result on error
+    } finally {
+      setAnalyzing(false);
+    }
+  };
+
   const getTrustScoreColor = (score: number) => {
     if (score >= 70) return "text-green-600"
     if (score >= 40) return "text-yellow-600"
@@ -142,7 +206,7 @@ export default function AnalyzePage() {
           />
           <div className="flex justify-between items-center">
             <span className="text-sm text-muted-foreground">{text.length}/5000 characters</span>
-            <Button onClick={handleAnalyze} disabled={analyzing || !text.trim()} size="lg">
+            <Button onClick={handleQuickAnalyze} disabled={analyzing || !text.trim()} size="lg">
               {analyzing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
               {analyzing ? "Analyzing..." : "Quick Analysis"}
             </Button>

--- a/frontend/app/api/quick_analyze/route.ts
+++ b/frontend/app/api/quick_analyze/route.ts
@@ -1,0 +1,101 @@
+import { type NextRequest, NextResponse } from "next/server";
+import { spawn } from "child_process";
+import path from "path";
+// No Supabase client needed here if quick_analyze doesn't save to DB.
+// If it does, or might in the future, you can add:
+// import { createServerClient } from "@/lib/supabase";
+
+// Define the expected structure for the quick analysis result.
+// This should match what your Python script's quick_analyze function returns.
+interface QuickAnalysisResult {
+  score?: number; // Making fields optional in case of error or different structure
+  indicator?: string;
+  explanation?: string[] | string; // Can be an array or single string
+  tip?: string;
+  // Add other fields if your quick_analyze Python function returns more
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { text, userId } = await request.json(); // Assuming userId might be used later
+
+    if (!text || typeof text !== "string") {
+      return NextResponse.json(
+        { error: "Invalid input: text is required and must be a string." },
+        { status: 400 }
+      );
+    }
+    // userId validation can be added if it becomes mandatory for this endpoint
+
+    const projectRoot = process.cwd();
+    const scriptPath = path.join(projectRoot, "biaslens", "analyzer.py");
+    const pythonExecutable = "python3"; // Or "python"
+
+    const analysis = await new Promise<QuickAnalysisResult>((resolve, reject) => {
+      const pythonProcess = spawn(pythonExecutable, [
+        scriptPath,
+        "quick_analyze", // Specify the function to call
+        text,
+      ]);
+
+      let stdoutData = "";
+      let stderrData = "";
+
+      pythonProcess.stdout.on("data", (data) => {
+        stdoutData += data.toString();
+      });
+
+      pythonProcess.stderr.on("data", (data) => {
+        stderrData += data.toString();
+      });
+
+      pythonProcess.on("close", (code) => {
+        if (code === 0) {
+          try {
+            // Trim stdoutData to remove potential trailing newlines from Python's print
+            const result = JSON.parse(stdoutData.trim());
+            resolve(result);
+          } catch (parseError) {
+            console.error("JSON parsing error in quick_analyze:", parseError);
+            console.error("Python stdout (quick_analyze):", stdoutData);
+            console.error("Python stderr (quick_analyze):", stderrData);
+            reject(new Error("Failed to parse Python script output for quick analysis."));
+          }
+        } else {
+          console.error(`Python script (quick_analyze) exited with code ${code}`);
+          console.error("Python stderr (quick_analyze):", stderrData);
+          console.error("Python stdout (quick_analyze):", stdoutData);
+          reject(new Error(`Python script error (quick_analyze): ${stderrData || "Unknown error"}`));
+        }
+      });
+
+      pythonProcess.on("error", (error) => {
+        console.error("Failed to start Python process (quick_analyze):", error);
+        if ((error as any).code === 'ENOENT') {
+          reject(new Error(`Python executable (${pythonExecutable}) not found. Please ensure Python is installed and in PATH.`));
+        } else {
+          reject(new Error("Failed to start Python script for quick analysis."));
+        }
+      });
+    });
+
+    // Unlike the main 'analyze' endpoint, quick_analyze results are typically not saved to the database.
+    // If you need to save them, you would add Supabase client initialization and insert logic here.
+    // For example:
+    // const supabase = createServerClient();
+    // const { error: dbError } = await supabase.from("quick_analysis_log").insert({ ... });
+    // if (dbError) { /* handle error */ }
+
+    return NextResponse.json(analysis);
+  } catch (error) {
+    console.error("Quick analysis endpoint error:", error);
+    let errorMessage = "Failed to perform quick analysis.";
+    if (error instanceof Error) {
+        errorMessage = error.message;
+    }
+    return NextResponse.json(
+      { error: errorMessage },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
This commit introduces the functionality for the "Quick Analysis" button on the analyze page.

Key changes:

1.  **Modified `biaslens/analyzer.py`**:
    *   The script now accepts a command-line argument ('analyze' or
        'quick_analyze') to determine which analysis function to run.
    *   It takes the text input as a second command-line argument.
    *   The result of the chosen function is printed to stdout as JSON.

2.  **Created `frontend/app/api/quick_analyze/route.ts`**:
    *   This new API route handles POST requests to `/api/quick_analyze`.
    *   It spawns the `biaslens/analyzer.py` script, passing
        "quick_analyze" and the input text as arguments.
    *   It captures and returns the JSON output from the Python script.

3.  **Updated `frontend/app/analyze/page.tsx`**:
    *   A new handler function, `handleQuickAnalyze`, was added.
    *   This function calls the `/api/quick_analyze` endpoint.
    *   The "Quick Analysis" button's `onClick` event is now bound to
        `handleQuickAnalyze`.
    *   The simpler result from `quick_analyze` is mapped to the
        existing `AnalysisResult` interface for display, with some fields
        marked as "N/A for Quick Analysis" or using default values.

This allows you to perform a faster, more lightweight analysis by clicking the "Quick Analysis" button, distinct from the more comprehensive "Deep Analysis".