### PR TITLE
Refactor: Remove quick analysis and rename deep analysis

### DIFF
--- a/FRONTEND/app/analyze/page.tsx
+++ b/FRONTEND/app/analyze/page.tsx
@@ -13,36 +13,6 @@ import { useRouter } from "next/navigation";
 
 // --- TypeScript Interfaces for API Responses ---
 
-// --- "Quick" Analysis Interfaces ---
-interface QuickToneAnalysisModel {
-  sentiment_label?: string | null;
-  sentiment_confidence?: number | null;
-}
-
-// LightweightNigerianBiasAssessmentModel is reused for bias_analysis in QuickAnalysisResult
-
-interface QuickManipulationAnalysisModel {
-  is_clickbait?: boolean | null;
-}
-
-interface QuickVeracitySignalsModel {
-  fake_news_risk_level?: string | null;
-  matched_suspicious_phrases?: string[] | null;
-}
-
-interface QuickAnalysisResult {
-  score: number | null;
-  indicator: string | null;
-  explanation: string | null;
-  tip: string | null;
-  // New structured fields for quick_analyze
-  tone_analysis?: QuickToneAnalysisModel | null;
-  bias_analysis?: LightweightNigerianBiasAssessmentModel | null; // Reusing this existing detailed model
-  manipulation_analysis?: QuickManipulationAnalysisModel | null;
-  veracity_signals?: QuickVeracitySignalsModel | null;
-}
-
-
 // --- "Core Solution" Interfaces for Deep Analysis (/analyze endpoint) ---
 interface ToneAnalysisModel { // For Deep Analysis
   primary_tone?: string | null;
@@ -150,8 +120,8 @@ interface DetailedSubAnalysesResult {
   lightweight_nigerian_bias?: LightweightNigerianBiasAssessmentModel | null;
 }
 
-// Main interface for Deep Analysis results - "Core Solution" Structure
-interface DeepAnalysisResult {
+// Main interface for Analysis results - "Core Solution" Structure
+interface AnalyseResult {
   trust_score: number | null;
   indicator: string | null;
   explanation: string[] | null;
@@ -167,8 +137,8 @@ interface DeepAnalysisResult {
   detailed_sub_analyses?: DetailedSubAnalysesResult | null;
 }
 
-type AnalysisResultType = QuickAnalysisResult | DeepAnalysisResult | null;
-type AnalysisMode = "quick" | "deep" | null;
+type AnalysisResultType = AnalyseResult | null;
+// AnalysisMode type is no longer needed as there's only one mode.
 
 // readableKeyMap should be defined outside the component if it doesn't need access to component's state/props
 // or inside if it does, or passed as a prop. For this case, outside is fine.
@@ -241,7 +211,7 @@ export default function AnalyzePage() {
   const [text, setText] = useState("")
   const [analyzing, setAnalyzing] = useState(false)
   const [result, setResult] = useState<AnalysisResultType>(null)
-  const [analysisMode, setAnalysisMode] = useState<AnalysisMode>(null)
+  // const [analysisMode, setAnalysisMode] = useState<AnalysisMode>(null) // Removed
   const [apiError, setApiError] = useState<string | null>(null)
   const { toast } = useToast()
   const router = useRouter()
@@ -351,47 +321,25 @@ export default function AnalyzePage() {
     }
   }, [user, authLoading, router])
 
-  const handleAnalyze = async () => { // This is for Quick Analysis
+  const handleAnalyse = async () => { // Renamed from handleDeepAnalyze
     if (!text.trim()) {
       toast({ title: "Error", description: "Please enter some text to analyze", variant: "destructive" })
       return
     }
-    setAnalyzing(true); setResult(null); setApiError(null); setAnalysisMode("quick");
-    try {
-      const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "";
-      const response = await fetch(`${apiBaseUrl}/quick_analyze`, {
-        method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ text: text.trim() }),
-      });
-      const responseData = await response.json();
-      if (!response.ok) throw new Error(responseData.detail || responseData.error || "Quick analysis failed");
-      setResult(responseData as QuickAnalysisResult);
-      toast({ title: "Quick Analysis Complete", description: "Text analyzed successfully!" });
-    } catch (error: any) {
-      console.error("Quick Analysis API Error:", error);
-      const errorMsg = error.message || "Failed to analyze text. Please try again.";
-      setApiError(errorMsg); toast({ title: "Error", description: errorMsg, variant: "destructive" });
-    } finally { setAnalyzing(false); }
-  }
-
-  const handleDeepAnalyze = async () => { // This is for Deep Analysis
-    if (!text.trim()) {
-      toast({ title: "Error", description: "Please enter some text to analyze", variant: "destructive" })
-      return
-    }
-    setAnalyzing(true); setResult(null); setApiError(null); setAnalysisMode("deep");
+    setAnalyzing(true); setResult(null); setApiError(null); // setAnalysisMode("deep") removed;
     try {
       const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "";
       const requestBody = { text: text.trim(), include_detailed_results: true, include_patterns: true, };
-      const response = await fetch(`${apiBaseUrl}/analyze`, {
+      const response = await fetch(`${apiBaseUrl}/analyze`, { // Endpoint is /analyze
         method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(requestBody),
       });
       const responseData = await response.json();
-      if (!response.ok) throw new Error(responseData.detail || responseData.error || "Deep analysis failed");
-      setResult(responseData as DeepAnalysisResult);
-      toast({ title: "Deep Analysis Complete", description: "Text deeply analyzed successfully!" });
+      if (!response.ok) throw new Error(responseData.detail || responseData.error || "Analysis failed");
+      setResult(responseData as AnalyseResult);
+      toast({ title: "Analysis Complete", description: "Text analyzed successfully!" });
     } catch (error: any) {
-      console.error("Deep Analysis API Error:", error);
-      const errorMsg = error.message || "Failed to deeply analyze text. Please try again.";
+      console.error("Analysis API Error:", error);
+      const errorMsg = error.message || "Failed to analyze text. Please try again.";
       setApiError(errorMsg); toast({ title: "Error", description: errorMsg, variant: "destructive" });
     } finally { setAnalyzing(false); }
   }
@@ -441,7 +389,7 @@ export default function AnalyzePage() {
     );
   };
 
-  const renderCoreSolutionDetails = (res: DeepAnalysisResult) => { // For Deep Analysis
+  const renderAnalyseSolutionDetails = (res: AnalyseResult) => { // Renamed from renderCoreSolutionDetails
     if (!res.tone_analysis && !res.bias_analysis && !res.manipulation_analysis && !res.veracity_signals) {
       return null;
     }
@@ -453,26 +401,6 @@ export default function AnalyzePage() {
           {res.bias_analysis && renderSubDetail("Bias Insights", res.bias_analysis, <EyeOff />, "Detected bias type, strength, and source.")}
           {res.manipulation_analysis && renderSubDetail("Manipulation Tactics", res.manipulation_analysis, <Fingerprint />, "Presence of clickbait or manipulative patterns.")}
           {res.veracity_signals && renderSubDetail("Veracity Signals", res.veracity_signals, <ShieldCheck />, "Indicators related to content reliability and authenticity.")}
-        </div>
-      </>
-    )
-  }
-
-  const renderQuickAnalysisCoreDetails = (res: QuickAnalysisResult) => {
-    if (!res.tone_analysis && !res.bias_analysis && !res.manipulation_analysis && !res.veracity_signals) {
-      return null;
-    }
-    return (
-      <>
-        <h2 className="text-xl font-semibold mt-6 mb-3 border-b pb-1">Quick Insights Overview</h2>
-        <div className="grid md:grid-cols-2 gap-4">
-          {res.tone_analysis && renderSubDetail("Quick Tone", res.tone_analysis, <MessageSquare />)}
-          {/* Bias Analysis for Quick Mode uses LightweightNigerianBiasAssessmentModel directly */}
-          {res.bias_analysis && (res.bias_analysis.inferred_bias_type && res.bias_analysis.inferred_bias_type !== "No specific patterns detected" && res.bias_analysis.inferred_bias_type !== "Nigerian context detected, specific bias type unclear from patterns") &&
-            renderSubDetail("Quick Pattern Bias", res.bias_analysis, <Sparkles />)
-          }
-          {res.manipulation_analysis && renderSubDetail("Quick Manipulation", res.manipulation_analysis, <Fingerprint />)}
-          {res.veracity_signals && renderSubDetail("Quick Veracity", res.veracity_signals, <SearchCheck />)}
         </div>
       </>
     )
@@ -490,28 +418,28 @@ export default function AnalyzePage() {
           <Textarea placeholder="Paste your text here..." value={text} onChange={(e) => setText(e.target.value)} className="min-h-[200px] text-base border-gray-300 focus:border-primary" maxLength={10000} />
           <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
             <span className="text-sm text-muted-foreground">{text.length}/10000 characters</span>
-            <div className="flex gap-4"> <Button onClick={handleAnalyze} disabled={analyzing || !text.trim()} size="lg" variant="outline"> {analyzing && analysisMode === 'quick' && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Quick Analysis </Button> <Button onClick={handleDeepAnalyze} disabled={analyzing || !text.trim()} size="lg"> {analyzing && analysisMode === 'deep' && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Deep Analysis </Button> </div>
+            <div className="flex gap-4"> <Button onClick={handleAnalyse} disabled={analyzing || !text.trim()} size="lg"> {analyzing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />} Analyze </Button> </div>
           </div>
         </CardContent>
       </Card>
-      {apiError && ( <Card className="mb-8 bg-red-50 dark:bg-red-900 border-red-500 dark:border-red-700"> <CardHeader> <CardTitle className="flex items-center gap-2 text-red-700 dark:text-red-300"> <AlertTriangle /> Analysis Error </CardTitle> </CardHeader> <CardContent> <p className="text-red-600 dark:text-red-400">{apiError}</p> </CardContent> </Card> )}
+      {apiError && ( <Card className="mb-8 bg-red-50 dark:bg-red-900 border-red-500 dark:border-red-700"> <CardHeader> <CardTitle className="flex items-center gap-2 text-red-700 dark:text-red-300"> <AlertTriangle /> Analysis Error </CardTitle> </CellHeader> <CardContent> <p className="text-red-600 dark:text-red-400">{apiError}</p> </CardContent> </Card> )}
       {result && !apiError && (
         <div className="space-y-6">
           <Card> {/* Overall Assessment Card */}
             <CardHeader> <CardTitle className="flex items-center gap-2"> <Gauge className="h-5 w-5 text-primary" /> Overall Assessment </CardTitle> </CardHeader>
             <CardContent className="space-y-4">
-              {((analysisMode === 'deep' && (result as DeepAnalysisResult).trust_score !== null) || (analysisMode === 'quick' && (result as QuickAnalysisResult).score !== null)) ? (
+              {(result as AnalyseResult).trust_score !== null ? (
                 <>
                   <div className="flex items-center justify-between">
                     <span className="text-3xl font-bold">
-                      <span className={getTrustScoreColor(analysisMode === 'deep' ? (result as DeepAnalysisResult).trust_score : (result as QuickAnalysisResult).score)}>
-                        {(analysisMode === 'deep' ? (result as DeepAnalysisResult).trust_score : (result as QuickAnalysisResult).score)}%
+                      <span className={getTrustScoreColor((result as AnalyseResult).trust_score)}>
+                        {(result as AnalyseResult).trust_score}%
                       </span>
                       <span className="text-xl ml-1">Trust Score</span>
                     </span>
-                    <Badge variant={ (((analysisMode === 'deep' ? (result as DeepAnalysisResult).trust_score : (result as QuickAnalysisResult).score) ?? 0) >= 70 ? "default" : (((analysisMode === 'deep' ? (result as DeepAnalysisResult).trust_score : (result as QuickAnalysisResult).score) ?? 0) >= 40 ? "secondary" : "destructive")) }> {result.indicator || "N/A"} </Badge>
+                    <Badge variant={ (((result as AnalyseResult).trust_score ?? 0) >= 70 ? "default" : (((result as AnalyseResult).trust_score ?? 0) >= 40 ? "secondary" : "destructive")) }> {result.indicator || "N/A"} </Badge>
                   </div>
-                  <Progress value={(analysisMode === 'deep' ? (result as DeepAnalysisResult).trust_score : (result as QuickAnalysisResult).score)} className="h-3" />
+                  <Progress value={(result as AnalyseResult).trust_score} className="h-3" />
                 </>
               ) : <p className="text-muted-foreground">Trust score not available.</p>}
               <div className="mt-4"> <h4 className="font-semibold mb-1">Explanation:</h4> {Array.isArray(result.explanation) ? (result.explanation as string[]).map((line, index) => <p key={index} className="text-muted-foreground leading-relaxed">{line}</p>) : <p className="text-muted-foreground leading-relaxed">{result.explanation || "No explanation provided."}</p> } </div>
@@ -519,42 +447,38 @@ export default function AnalyzePage() {
             </CardContent>
           </Card>
 
-          {/* Render "Core Solution" details for Deep Analysis */}
-          {analysisMode === 'deep' && renderCoreSolutionDetails(result as DeepAnalysisResult)}
+          {/* Render "Core Solution" details for Analysis */}
+          {renderAnalyseSolutionDetails(result as AnalyseResult)}
 
-          {/* Render "Core Solution" details for Quick Analysis */}
-          {analysisMode === 'quick' && renderQuickAnalysisCoreDetails(result as QuickAnalysisResult)}
-
-          {/* Display LightweightNigerianBiasAssessment for Deep Analysis (if not covered by quick's bias_analysis)
-              Note: Quick mode's bias_analysis IS the LightweightNigerianBiasAssessment.
-              For Deep mode, it's a separate top-level field if patterns are included.
+          {/* Display LightweightNigerianBiasAssessment for Analysis
+              For Analysis mode, it's a separate top-level field if patterns are included.
           */}
-          {analysisMode === 'deep' && (result as DeepAnalysisResult).lightweight_nigerian_bias_assessment?.inferred_bias_type &&
-            (result as DeepAnalysisResult).lightweight_nigerian_bias_assessment?.inferred_bias_type !== "No specific patterns detected" &&
-            (result as DeepAnalysisResult).lightweight_nigerian_bias_assessment?.inferred_bias_type !== "Nigerian context detected, specific bias type unclear from patterns" &&
+          {(result as AnalyseResult).lightweight_nigerian_bias_assessment?.inferred_bias_type &&
+            (result as AnalyseResult).lightweight_nigerian_bias_assessment?.inferred_bias_type !== "No specific patterns detected" &&
+            (result as AnalyseResult).lightweight_nigerian_bias_assessment?.inferred_bias_type !== "Nigerian context detected, specific bias type unclear from patterns" &&
           (
             <Card>
               <CardHeader> <CardTitle className="flex items-center gap-2"> <Sparkles className="h-5 w-5 text-purple-500" /> Lightweight Nigerian Bias Assessment </CardTitle> <CardDescription>Rule-based detection of Nigerian-specific bias patterns.</CardDescription> </CardHeader>
               <CardContent className="space-y-3 text-sm">
-                <div><span className="font-semibold">Inferred Bias Type:</span> {(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.inferred_bias_type}</div>
-                {(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.bias_category && <div><span className="font-semibold">Category:</span> <Badge variant="outline">{(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.bias_category}</Badge></div>}
-                {(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.bias_target && <div><span className="font-semibold">Target:</span> <Badge variant="outline">{(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.bias_target}</Badge></div>}
-                {(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.matched_keywords && (result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.matched_keywords!.length > 0 && (
-                  <div> <span className="font-semibold">Matched Keywords:</span> <div className="flex flex-wrap gap-1 mt-1"> {(result as DeepAnalysisResult).lightweight_nigerian_bias_assessment!.matched_keywords!.map(keyword => ( <Badge key={keyword} variant="secondary" className="text-xs">{keyword}</Badge> ))} </div> </div>
+                <div><span className="font-semibold">Inferred Bias Type:</span> {(result as AnalyseResult).lightweight_nigerian_bias_assessment!.inferred_bias_type}</div>
+                {(result as AnalyseResult).lightweight_nigerian_bias_assessment!.bias_category && <div><span className="font-semibold">Category:</span> <Badge variant="outline">{(result as AnalyseResult).lightweight_nigerian_bias_assessment!.bias_category}</Badge></div>}
+                {(result as AnalyseResult).lightweight_nigerian_bias_assessment!.bias_target && <div><span className="font-semibold">Target:</span> <Badge variant="outline">{(result as AnalyseResult).lightweight_nigerian_bias_assessment!.bias_target}</Badge></div>}
+                {(result as AnalyseResult).lightweight_nigerian_bias_assessment!.matched_keywords && (result as AnalyseResult).lightweight_nigerian_bias_assessment!.matched_keywords!.length > 0 && (
+                  <div> <span className="font-semibold">Matched Keywords:</span> <div className="flex flex-wrap gap-1 mt-1"> {(result as AnalyseResult).lightweight_nigerian_bias_assessment!.matched_keywords!.map(keyword => ( <Badge key={keyword} variant="secondary" className="text-xs">{keyword}</Badge> ))} </div> </div>
                 )}
               </CardContent>
             </Card>
           )}
 
-          {analysisMode === 'deep' && (result as DeepAnalysisResult).detailed_sub_analyses && (
+          {(result as AnalyseResult).detailed_sub_analyses && (
             <>
               <h2 className="text-2xl font-semibold mt-8 mb-4 border-b pb-2">Detailed Sub-Analyses</h2>
               <div className="grid md:grid-cols-2 gap-6">
-                {renderSubDetail("Sentiment Details (Full)", (result as DeepAnalysisResult).detailed_sub_analyses?.sentiment, <MessageSquare />)}
-                {renderSubDetail("Emotion Details (Full)", (result as DeepAnalysisResult).detailed_sub_analyses?.emotion, <Zap />)}
-                {renderSubDetail("Bias Details (Full ML)", (result as DeepAnalysisResult).detailed_sub_analyses?.bias, <EyeOff />)}
-                {(result as DeepAnalysisResult).detailed_sub_analyses?.patterns && renderSubDetail("Pattern Details (Full)", (result as DeepAnalysisResult).detailed_sub_analyses?.patterns, <Newspaper />)}
-                {(result as DeepAnalysisResult).detailed_sub_analyses?.lightweight_nigerian_bias && renderSubDetail("Lightweight Nigerian Bias (Full)", (result as DeepAnalysisResult).detailed_sub_analyses?.lightweight_nigerian_bias, <Sparkles />)}
+                {renderSubDetail("Sentiment Details (Full)", (result as AnalyseResult).detailed_sub_analyses?.sentiment, <MessageSquare />)}
+                {renderSubDetail("Emotion Details (Full)", (result as AnalyseResult).detailed_sub_analyses?.emotion, <Zap />)}
+                {renderSubDetail("Bias Details (Full ML)", (result as AnalyseResult).detailed_sub_analyses?.bias, <EyeOff />)}
+                {(result as AnalyseResult).detailed_sub_analyses?.patterns && renderSubDetail("Pattern Details (Full)", (result as AnalyseResult).detailed_sub_analyses?.patterns, <Newspaper />)}
+                {(result as AnalyseResult).detailed_sub_analyses?.lightweight_nigerian_bias && renderSubDetail("Lightweight Nigerian Bias (Full)", (result as AnalyseResult).detailed_sub_analyses?.lightweight_nigerian_bias, <Sparkles />)}
               </div>
             </>
           )}

--- a/main.py
+++ b/main.py
@@ -3,8 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel # Removed List, Optional, Dict, Any from here
 from typing import List, Optional, Dict, Any # Added these types from typing
 
-from biaslens.analyzer import analyze as perform_analyze
-from biaslens.analyzer import quick_analyze as perform_quick_analyze
+from biaslens.analyzer import analyse as perform_analyse
 
 # --- Pydantic Models for /analyze Response ("Core Solution" Structure) ---
 
@@ -47,7 +46,7 @@ class DetailedSubAnalysesModel(BaseModel):
 
 # --- Main Response Model for /analyze ---
 
-class AnalyzeResponseModel(BaseModel):
+class AnalyseResponseModel(BaseModel):
     trust_score: Optional[float] = None
     indicator: Optional[str] = None
     explanation: Optional[List[str]] = None
@@ -61,41 +60,13 @@ class AnalyzeResponseModel(BaseModel):
     lightweight_nigerian_bias_assessment: Optional[LightweightNigerianBiasAssessmentModel] = None
     detailed_sub_analyses: Optional[DetailedSubAnalysesModel] = None
 
-# --- Pydantic Models for /quick_analyze Response ("Core Solution" Aligned) ---
-
-class QuickToneAnalysisModel(BaseModel):
-    sentiment_label: Optional[str] = None
-    sentiment_confidence: Optional[float] = None
-
-class QuickManipulationAnalysisModel(BaseModel):
-    is_clickbait: Optional[bool] = None
-
-class QuickVeracitySignalsModel(BaseModel):
-    fake_news_risk_level: Optional[str] = None
-    matched_suspicious_phrases: Optional[List[str]] = None
-
-
-class QuickAnalysisResponseModel(BaseModel):
-    score: Optional[float] = None
-    indicator: Optional[str] = None
-    explanation: Optional[str] = None
-    tip: Optional[str] = None
-
-    tone_analysis: Optional[QuickToneAnalysisModel] = None
-    bias_analysis: Optional[LightweightNigerianBiasAssessmentModel] = None
-    manipulation_analysis: Optional[QuickManipulationAnalysisModel] = None
-    veracity_signals: Optional[QuickVeracitySignalsModel] = None
-
 # --- Request Models ---
 
-class TextAnalysisRequest(BaseModel): # For /analyze endpoint
+class TextAnalyseRequest(BaseModel): # For /analyze endpoint
     text: str
     headline: Optional[str] = None
     include_patterns: bool = True
     include_detailed_results: bool = False
-
-class QuickAnalysisRequest(BaseModel): # For /quick_analyze endpoint
-    text: str
 
 app = FastAPI(
     title="BiasLens API",
@@ -122,25 +93,15 @@ app.add_middleware(
 async def read_root():
     return {"message": "Welcome to the BiasLens API!"}
 
-@app.post("/analyze", response_model=AnalyzeResponseModel)
-async def analyze_text(request: TextAnalysisRequest):
+@app.post("/analyze", response_model=AnalyseResponseModel)
+async def analyze_text(request: TextAnalyseRequest):
     '''
     Performs comprehensive analysis on the provided text.
     '''
-    analysis_results = perform_analyze(
+    analysis_results = perform_analyse(
         text=request.text,
         headline=request.headline,
         include_patterns=request.include_patterns,
         include_detailed_results=request.include_detailed_results
     )
     return analysis_results
-
-@app.post("/quick_analyze", response_model=QuickAnalysisResponseModel)
-async def quick_analyze_text(request: QuickAnalysisRequest):
-    '''
-    Performs a quick analysis on the provided text.
-    '''
-    quick_analysis_results = perform_quick_analyze(
-        text=request.text
-    )
-    return quick_analysis_results


### PR DESCRIPTION
I've removed the 'quick_analyze' functionality entirely from the backend and frontend. I've also renamed 'deep_analyze' to 'analyse' in the backend and updated the frontend to reflect this change.

Specific changes:
- Removed `quick_analyze` function from `biaslens/analyzer.py`.
- Removed the `/quick_analyze` route, its Pydantic models, and associated imports from `main.py`.
- Renamed `analyze` function to `analyse` in `biaslens/analyzer.py`.
- Updated `main.py` to use the new `analyse` function name and renamed relevant Pydantic models from `Analyze...` to `Analyse...`.
- Updated `FRONTEND/app/analyze/page.tsx` to:
    - Remove the "Quick Analysis" button and its handler (`handleAnalyze`).
    - Remove UI components and logic related to displaying quick analysis results.
    - Rename "Deep Analysis" button to "Analyze".
    - Rename `handleDeepAnalyze` to `handleAnalyse`.
    - Rename `DeepAnalysisResult` interface to `AnalyseResult` and update its usages.
    - Update toast messages and console logs.