### PR TITLE
Hide Primary Tone and Source of Primary Bias in analysis results

### DIFF
--- a/FRONTEND/app/analyze/page.tsx
+++ b/FRONTEND/app/analyze/page.tsx
@@ -176,6 +176,8 @@ export default function AnalyzePage() {
   const renderFieldValue = (originalKey: string, value: any, isNested: boolean = false): React.ReactNode => {
     // Keys to explicitly ignore
     const keysToIgnore: string[] = [
+      "primary_tone",
+      "source_of_primary_bias",
       "ml_model_confidence",
       "sentiment_confidence",
       "confidence", // Exact match for 'confidence'


### PR DESCRIPTION
This commit updates the analysis page to hide specific fields from the displayed results as per your request:
- "Primary Tone" is now hidden from the "Tone & Sentiment" section.
- "Source of Primary Bias" is now hidden from the "Bias Insights" section.

These fields were hidden by adding their respective keys ('primary_tone' and 'source_of_primary_bias') to the 'keysToIgnore' list in the `renderFieldValue` function in `FRONTEND/app/analyze/page.tsx`.